### PR TITLE
Fix vocabulary-uri codelist matching (1.05)

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -88,8 +88,7 @@ def match_codelist(path):
     """
     for mapping in codelist_mappings:
         if mapping.find('path').text.startswith('//'):
-            #print mapping.find('path').text.strip('/'), path
-            if mapping.find('path').text.strip('/') in path:
+            if path.endswith(mapping.find('path').text.strip('/')):
                 codelist = mapping.find('codelist').attrib['ref']
                 if not path in codelists_paths[codelist]:
                     codelists_paths[codelist].append(path)


### PR DESCRIPTION
Some elements have both a @vocabulary and a @vocabulary-uri attribute for example, iati-activities/iati-activity/sector. The vocabulary attribute has a codelist to validate it, while the -uri one does not.

Without this fix, the XPath was being checked to see whether it was merely within a string rather than at the end. This meant that incorrect matches were being made due to the additional characters at the end of the -uri attribute.