### PR TITLE
Deal with incomplete Codelists when generating element pages - V1.04

### DIFF
--- a/templates/en/schema_element.rst
+++ b/templates/en/schema_element.rst
@@ -44,7 +44,7 @@ Attributes
   {{ textwrap.dedent(text).strip().replace('\n','\n  ') }}
 
 {% set codelist = match_codelist(path+element_name+'/@'+attribute) %}{% if attribute_type %}
-  This value should be of type {{attribute_type}}.
+  This value must be of type {{attribute_type}}.
 
 {% endif %}{% if codelist %}
   This value {% if is_complete_codelist(codelist) %}must{% else %}should{% endif %} be on the :doc:`{{codelist}} codelist </codelists/{{codelist}}>`.

--- a/templates/en/schema_element.rst
+++ b/templates/en/schema_element.rst
@@ -47,7 +47,7 @@ Attributes
   This value must be of type {{attribute_type}}.
 
 {% endif %}{% if codelist %}
-  This value {% if is_complete_codelist(codelist) %}must{% else %}should{% endif %} be on the :doc:`{{codelist}} codelist </codelists/{{codelist}}>`.
+  This value {% if codelist|is_complete_codelist() %}must{% else %}should{% endif %} be on the :doc:`{{codelist}} codelist </codelists/{{codelist}}>`.
 
 {% endif %}
 


### PR DESCRIPTION
This adds a check that outputs 'should' rather than 'must' where Codelists are incomplete.

Well, attempts to. This is attempt number 2 and tries to use custom filters.

Helpfully, the template is different at different integers.