### PR TITLE
Update script to deal with branch protection

### DIFF
--- a/update_submodules.sh
+++ b/update_submodules.sh
@@ -1,12 +1,17 @@
 # Script to update each of the 4 submodules in the IATI-SSOT repository
 # 
 
+timestamp=$(date +%s)
+
 for version in 1.04 1.05 2.01 2.02; do
 	# Checkout to the specified version for the SSOT directory
 	git checkout version-$version
 
 	# Pull the latest code from origin for this version (i.e. Git branch) of the SSOT directory
 	git pull origin version-$version
+
+	# Check out a new branch to get around branch protection
+	git checkout -b update-submodules-$timestamp-$version
 
 	# Loop over each subfolder, pull the latest version and add to staging
 	for folder in IATI-Codelists IATI-Extra-Documentation IATI-Schemas IATI-Rulesets; do
@@ -27,8 +32,8 @@ for version in 1.04 1.05 2.01 2.02; do
 	done
 	
 	# Commit updated submodules
-	git commit -m "Updated submodules (using script)"
+	git commit -m "Updated submodules (using script) "$version
 	
 	# Push to the server
-	git push origin version-$version
+	git push origin update-submodules-$timestamp-$version
 done


### PR DESCRIPTION
The version branches now have branch protection on Github, so cannot be pushed to directly.

This updates a script to create new branches rather than attempting to push to the version branches directly.

Branch names contain a timestamp to act as a near-enough UID.