### PR TITLE
v1.04 Stop addition of 'Last updated on' info to pages

### DIFF
--- a/combined_gen.sh
+++ b/combined_gen.sh
@@ -18,9 +18,6 @@ cp ../combined_sitemap.rst en/sitemap.rst
 
 git add .
 git commit -a -m 'Auto'
-git ls-tree -r --name-only HEAD | grep 'rst$' | while read filename; do
-    echo $'\n\n\n'"*Last updated on $(git log -1 --format="%ad" --date=short -- $filename)*" >> $filename
-done
 
 cd .. || exit 1
 ./gen_html.sh || exit $?

--- a/last_updated_gen.sh
+++ b/last_updated_gen.sh
@@ -3,8 +3,5 @@
 cd docs || exit 1
 git add .
 git commit -a -m 'Auto'
-git ls-tree -r --name-only HEAD | grep 'rst$' | while read filename; do
-    echo $'\n\n\n'"*Last updated on $(git log -1 --format="%ad" --date=short -- $filename)*" >> $filename
-done
 cd .. || exit 1
 ./gen_html.sh || exit $?


### PR DESCRIPTION
Fixes IATI/IATI-Codelists-NonEmbedded#156

It's been agreed within the IATI Technical Team that this will be removed from the website at the moment, and re-assesed as a potential feature with the updated website architecture.

This is due to a combination of:

* Dates of any kind do not appear on some pages
* Incorrect dates appear on various pages where there are dates
* Where they are correct, the age of the dates doesn't provide much information beyond 'this hasn't been updated in a while'
* There are separate changelogs for when key information changes, providing more information that just the date