### PR TITLE
v2.02 Remove info about Last update time

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ IATI Standard SSOT
 Introduction
 ------------
 
-This is the main github repository for the IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see http://iatistandard.org/developer/ssot/ 
+This is the main github repository for the IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see http://iatistandard.org/developer/ssot/
 
 Building the documentation
 ==========================
@@ -29,7 +29,7 @@ Fetch the source code:::
     git clone https://github.com/IATI/IATI-Standard-SSOT.git
 
 Pull in the git submodules:::
-    
+
     git submodule init
     git submodule update
 
@@ -46,19 +46,19 @@ Set up a virtual environment:
 
     # Install python requirements
     pip install -r requirements.txt
-    
+
 Build the documentation:::
 
     ./gen.sh
 
-The built documentation is now in ``docs/<language>/_build/dirhtml`` 
+The built documentation is now in ``docs/<language>/_build/dirhtml``
 
 
 Editing the documentation
 =========================
 
 Make any changes in ``IATI-Extra-Documentation``, as the ``docs`` directory is generated from
-this and other sources each time ``./gen.sh`` is run. 
+this and other sources each time ``./gen.sh`` is run.
 
 
 Building a website that also includes additonal guidance
@@ -85,5 +85,3 @@ To generate a copy of the website with these extra repositories included, run:
    ./combined_gen.sh
 
 This generates the website in the ``docs`` directory, but then copies it to ``docs-copy`` at the end, so that a webserver can be pointed to ``docs-copy/en/_build/dirhtml`` and not be interrupted when the site is being rebuilt.
-
-The ``docs`` directory should be a git repository in order to support adding the "Last updated" line to the bottom of the page. We build the live and dev websites in different directories so that the last updated date corresponds to when the site was actually changed, not when the relevant commit was added to the source git respository.


### PR DESCRIPTION
#114 and #115 removed the addition of dates to pages. This removes the corresponding text from the README.

There is no corresponding text in the v1 READMEs.