### PR TITLE
Document codelist items on text nodes

### DIFF
--- a/templates/en/codelist.rst
+++ b/templates/en/codelist.rst
@@ -19,7 +19,11 @@ This is a :ref:`Non-Embedded codelist <non_embedded_codelist>`.
 Use this codelist for
 ---------------------
 {% for path in codelist_paths %}
+{% if path.endswith('/text()') %}
+* :doc:`{{path}} </{% if path.startswith('iati-activities') %}activity-standard{% else %}organisation-standard{% endif %}/{{path.replace('/text()', '')}}>`
+{% else %}
 * :ref:`{{path}} <{{path_to_ref(path)}}>`
+{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/templates/en/schema_element.rst
+++ b/templates/en/schema_element.rst
@@ -19,6 +19,11 @@ Rules
 {% if extended_type.startswith('xsd:') %}The text in this element must be of type {{extended_type}}.{% endif %}
 {% endfor %}
 
+{% set codelist_tuple = match_codelist(path+element_name+'/text()') %}
+{% if codelist_tuple[0] %}
+The text in this element {% if codelist_tuple[0]|is_complete_codelist() %}must{% else %}should{% endif %} be on the :doc:`{{codelist_tuple[0]}} codelist </codelists/{{codelist_tuple[0]}}>`{% if codelist_tuple[1] %}, if the relevant vocabulary is used{% endif %}.
+{% endif %}
+
 {% if element.get('type') and element.get('type').startswith('xsd:') %}The text in this element must be of type {{element.get('type')}}.
 {% endif %}
 


### PR DESCRIPTION
This fix isn’t exactly beautiful, but probably no worse than the code that’s already there.

---

In practice, this adds the following documentation:

1. To `codelists/CRSChannelCode`:

    > ## Use this codelist for
    >  * [//iati-activity/crs-add/channel-code/text()](http://iatistandard.org/202/activity-standard/iati-activities/iati-activity/crs-add/channel-code/)

2. To `activity-standard/iati-activities/iati-activity/crs-add/channel-code`:

    > ## Rules
    > […]
    > The text in this element must be on the [_CRSChannelCode codelist_](http://iatistandard.org/202/codelists/CRSChannelCode/).

This fixes the issue described in https://github.com/IATI/IATI-Codelists/pull/109#issuecomment-344554911.