### PR TITLE
Schema docs generation extended types

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -384,7 +384,6 @@ class Schema2Doc(object):
                 str: minimum number of occurances,
                 str: maximum number of occurances (could be a number or 'unbounded')
         """
-
         a = element.attrib
         type_elements = []
         if 'type' in a:
@@ -392,6 +391,15 @@ class Schema2Doc(object):
             if complexType is not None:
                 type_elements = ( complexType.findall('xsd:choice/xsd:element', namespaces=namespaces) +
                     complexType.findall('xsd:sequence/xsd:element', namespaces=namespaces) )
+
+                # If this complexType is an extension of another complexType, find the base element and include any child elements
+                try:
+                    base_name = complexType.find('.//xsd:complexContent/xsd:extension', namespaces=namespaces).attrib.get('base')
+                    base_type_element = self.get_schema_element('complexType', base_name)
+                    type_elements += ( base_type_element.findall('xsd:choice/xsd:element', namespaces=namespaces) + base_type_element.findall('xsd:sequence/xsd:element', namespaces=namespaces) )
+                except AttributeError:
+                    pass
+                    # This complexType is not extended from a complexType base
 
         children = ( element.findall('xsd:complexType/xsd:choice/xsd:element', namespaces=namespaces)
             + element.findall('xsd:complexType/xsd:sequence/xsd:element', namespaces=namespaces)

--- a/gen.py
+++ b/gen.py
@@ -442,6 +442,15 @@ class Schema2Doc(object):
         type_attributeGroups = []
         if 'type' in a:
             complexType = self.get_schema_element('complexType', a['type'])
+
+            # If this complexType is an extension of another complexType, find the base element and use this to find any attributes
+            try:
+                base_name = complexType.find('.//xsd:complexContent/xsd:extension', namespaces=namespaces).attrib.get('base')
+                complexType = self.get_schema_element('complexType', base_name)
+            except AttributeError:
+                pass
+                # This complexType is not extended from a complexType base
+
             if complexType is None:
                 print('Notice: No attributes for', a['type'])
             else:

--- a/gen.py
+++ b/gen.py
@@ -224,8 +224,7 @@ class Schema2Doc(object):
 
 
     def output_docs(self, element_name, path, element=None, minOccurs='', maxOccurs='', ref_element=None, type_element=None):
-        """
-        Output documentation for the given element, and it's children.
+        """Output documentation for the given element, and it's children.
 
         If element is not given, we try to find it in the schema using it's
         element_name.


### PR DESCRIPTION
Adds support for documentation of `complexType` elements (that extend other `complexType` elements), which are added in the v2.03 schemas.