### PR TITLE
Add support for multiple codelists for a path (v2.03)

### DIFF
--- a/templates/en/schema_element.rst
+++ b/templates/en/schema_element.rst
@@ -60,14 +60,14 @@ Attributes
 {% if required %}
   This attribute is required.
 
-{% endif %}{% set codelist_tuple = match_codelist(path+element_name+'/@'+attribute) %}{% if attribute_type %}
+{% endif %}{% set codelist_tuples = match_codelists(path+element_name+'/@'+attribute) %}{% if attribute_type %}
 
   This value must be of type {{attribute_type}}.
 
-{% endif %}{% if codelist_tuple[0] %}
+{% endif %}{% for codelist_tuple in codelist_tuples %}
   This value {% if codelist_tuple[0]|is_complete_codelist() %}must{% else %}should{% endif %} be on the :doc:`{{codelist_tuple[0]}} codelist </codelists/{{codelist_tuple[0]}}>`{% if codelist_tuple[1] %}, if the relevant vocabulary is used{% endif %}.
 
-{% endif %}
+{% endfor %}
 
   {{ '\n\n  '.join(ruleset_text(path+element_name+'/@'+attribute)) }}{% endfor %}
 

--- a/templates/en/schema_table.rst
+++ b/templates/en/schema_table.rst
@@ -18,7 +18,7 @@
       - {%if not row.section%}{%if row.name%}:doc:`{{row.name}} <{{row.doc}}>`{%else%}{{row.attribute_name}}{%endif%}{%endif%}
       - {{row.description.replace('\n', '\n        ').strip(' \n')}}
       - {% if row.type %}{{row.type}}{% endif %}
-      - {% set codelist_tuple = match_codelist(root_path+row.path) %}{% if codelist_tuple[0] %}{%if codelist_tuple[1]%}({%endif%}:doc:`/codelists/{{codelist_tuple[0]}}`{%if codelist_tuple[1]%}){%endif%}{% endif %}
+      - {% set codelist_tuples = match_codelists(root_path+row.path) %}{% for codelist_tuple in codelist_tuples %}{%if codelist_tuple[1]%}({%endif%}:doc:`/codelists/{{codelist_tuple[0]}}`{%if codelist_tuple[1]%}){%endif%}{% endfor %}
       - {{row.path.replace('@','\@')}}
       - {{row.occur}}
       - {{'\n        '.join(ruleset_text(row.path))}}


### PR DESCRIPTION
Refs IATI/IATI-Codelists#140.

Testing this for e.g. `iati-activity/sector/@code`, I see:

> `@code`
> 
> > The code for the sector.
> >
> > This attribute is required.
> >
> > This value must be of type xsd:string.
> >
> > This value must be on the _[Sector codelist](http://localhost:8000/codelists/Sector/)_, if the relevant vocabulary is used.
> >
> > This value must be on the _[SectorCategory codelist](http://localhost:8000/codelists/SectorCategory/)_, if the relevant vocabulary is used.