### PR TITLE
Track relevant submodule branches (v2.03)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,16 @@
 [submodule "IATI-Schemas"]
 	path = IATI-Schemas
 	url = https://github.com/IATI/IATI-Schemas.git
+	branch = version-2.03
 [submodule "IATI-Rulesets"]
 	path = IATI-Rulesets
 	url = https://github.com/IATI/IATI-Rulesets.git
+	branch = version-2.03
 [submodule "IATI-Codelists"]
 	path = IATI-Codelists
 	url = https://github.com/IATI/IATI-Codelists.git
+	branch = version-2.03
 [submodule "IATI-Extra-Documentation"]
 	path = IATI-Extra-Documentation
 	url = https://github.com/IATI/IATI-Extra-Documentation.git
+	branch = version-2.03

--- a/update_submodules.sh
+++ b/update_submodules.sh
@@ -13,23 +13,16 @@ for version in 1.04 1.05 2.01 2.02 2.03; do
 	# Check out a new branch to get around branch protection
 	git checkout -b update-submodules-$timestamp-$version
 
-	# Loop over each subfolder, pull the latest version and add to staging
-	for folder in IATI-Codelists IATI-Extra-Documentation IATI-Schemas IATI-Rulesets; do
-		# Enter the specified folder (which contains the submodule)
-		cd $folder
+	# Discard local changes to submodules
+	# See: https://stackoverflow.com/a/27415757/2323348
+	git submodule deinit -f .
+	git submodule update --init
 
-		# Ensure that we are on the correct branch (i.e. Git branch)
-		git checkout version-$version
+	# Pull the latest versions of submodules
+	git submodule update --remote
 
-		# Pull the latest code from origin for this version (i.e. Git branch)
-		git pull origin version-$version
-
-		# Go back to the SSOT folder
-		cd ..
-
-		# Add the specified folder (which contains the submodule) to staging
-		git add $folder
-	done
+	# Git add submodules
+	git add IATI-Codelists IATI-Extra-Documentation IATI-Schemas IATI-Rulesets
 
 	# Commit updated submodules
 	git commit -m "Updated submodules (using script) "$version

--- a/update_submodules.sh
+++ b/update_submodules.sh
@@ -4,19 +4,19 @@
 timestamp=$(date +%s)
 
 for version in 1.04 1.05 2.01 2.02 2.03; do
+	# fetch the latest version from the remote
+	git fetch origin version-$version
+
 	# Checkout to the specified version for the SSOT directory
-	git checkout version-$version
-
-	# Pull the latest code from origin for this version (i.e. Git branch) of the SSOT directory
-	git pull origin version-$version
-
-	# Check out a new branch to get around branch protection
-	git checkout -b update-submodules-$timestamp-$version
+	git checkout --force origin/version-$version
 
 	# Discard local changes to submodules
 	# See: https://stackoverflow.com/a/27415757/2323348
 	git submodule deinit -f .
 	git submodule update --init
+
+	# Check out a new branch to get around branch protection
+	git checkout -b update-submodules-$timestamp-$version
 
 	# Pull the latest versions of submodules
 	git submodule update --remote


### PR DESCRIPTION
Fixes #2.
Also fixes #168.

It looks like [there’s a bit of the update_submodules script](https://github.com/IATI/IATI-Standard-SSOT/blob/666472c8df14d4b5bb85b57437b71626782d1334/update_submodules.sh#L17-L32) that currently updates each submodule individually. But if you specify a branch, git will do this natively.