### PR TITLE
Move guidance to the right places so TOC gen works

### DIFF
--- a/combined_gen.sh
+++ b/combined_gen.sh
@@ -9,12 +9,14 @@ mkdir en/developer
 cp -n ../../IATI-Developer-Documentation/*.rst en/developer
 cp -rn ../../IATI-Developer-Documentation/*/ en/developer
 mkdir en/guidance
-cp -n ../..//IATI-Guidance/en/*.rst en/guidance
-cp -rn ../../IATI-Guidance/en/*/ en/guidance
+cp -n ../../IATI-Guidance/en/*.rst en/guidance
+cp -rn ../../IATI-Guidance/en/datastore/ en/guidance/datastore/
+cp -rn ../../IATI-Guidance/en/how-to-publish/ en/guidance/how-to-publish/
+cp -rn ../../IATI-Guidance/en/upgrades en/guidance
+cp -rn ../../IATI-Guidance/en/introduction en/guidance
 mv en/guidance/404.rst en/
 mv en/guidance/upgrades* en/
 mv en/guidance/introduction* en/
-mv en/guidance/key-considerations* en/
 mv en/guidance/license* en/
 cp ../combined_sitemap.rst en/sitemap.rst
 


### PR DESCRIPTION
I’m not totally sure whether this is correct… It fixes lots of warnings, but it’s possible it causes a couple of new ones.