### PR TITLE
Add initial travis yaml (v2.03)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq libxml2-utils
+script:
+    - ./gen.sh

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 IATI Standard SSOT
 ==================
 
-.. image:: https://requires.io/github/IATI/IATI-Standard-SSOT/requirements.svg?branch=version-2.01
-    :target: https://requires.io/github/IATI/IATI-Standard-SSOT/requirements/?branch=version-2.01
+.. image:: https://requires.io/github/IATI/IATI-Standard-SSOT/requirements.svg?branch=version-2.03
+    :target: https://requires.io/github/IATI/IATI-Standard-SSOT/requirements/?branch=version-2.03
     :alt: Requirements Status
 .. image:: https://img.shields.io/badge/license-MIT-blue.svg
-    :target: https://github.com/IATI/IATI-Standard-SSOT/blob/version-2.01/LICENSE
+    :target: https://github.com/IATI/IATI-Standard-SSOT/blob/version-2.03/LICENSE
 
 Introduction
 ------------

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 IATI Standard SSOT
 ==================
 
+.. image:: https://travis-ci.org/IATI/IATI-Standard-SSOT.svg?branch=version-2.03
+    :target: https://travis-ci.org/IATI/IATI-Standard-SSOT
 .. image:: https://requires.io/github/IATI/IATI-Standard-SSOT/requirements.svg?branch=version-2.03
     :target: https://requires.io/github/IATI/IATI-Standard-SSOT/requirements/?branch=version-2.03
     :alt: Requirements Status


### PR DESCRIPTION
Refs #169.

This just clones the repos, installs the requirements, and attempts to build (part of) the site. ~~However, it already demonstrates that the SSOT errors at present (as a result of #165)~~:
[![Build Status](https://travis-ci.org/andylolz/IATI-Standard-SSOT.svg?branch=169-travis-init)](https://travis-ci.org/andylolz/IATI-Standard-SSOT)

…so it’s already useful.

For this to work, it’s necessary to:

 1. Merge this PR
 2. activate the repository on Travis CI (dot com) just here: https://travis-ci.com/IATI/IATI-Standard-SSOT