### PR TITLE
Show withdrawn codelist codes as withdrawn (v2.03)

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -503,10 +503,7 @@ def codelists_to_docs(lang):
         if not fname.endswith('.json'): continue
         with open(json_file) as fp:
             codelist_json = json.load(fp)
-            for i, x in enumerate(codelist_json['data']):
-                    if ('status' in x and x['status'] != 'active'):
-                        codelist_json['data'][i]['code'] = codelist_json['data'][i]['code'] + " (withdrawn)"
-
+            
         fname = fname[:-5]
         embedded = os.path.exists(os.path.join('IATI-Codelists','xml',fname+'.xml'))
         if embedded:

--- a/gen.py
+++ b/gen.py
@@ -503,6 +503,9 @@ def codelists_to_docs(lang):
         if not fname.endswith('.json'): continue
         with open(json_file) as fp:
             codelist_json = json.load(fp)
+            for i, x in enumerate(codelist_json['data']):
+                    if ('status' in x and x['status'] != 'active'):
+                        codelist_json['data'][i]['code'] = codelist_json['data'][i]['code'] + " (withdrawn)"
 
         fname = fname[:-5]
         embedded = os.path.exists(os.path.join('IATI-Codelists','xml',fname+'.xml'))
@@ -519,7 +522,7 @@ def codelists_to_docs(lang):
                 codelist_json=codelist_json,
                 show_category_column=not all(not 'category' in x for x in codelist_json['data']),
                 show_url_column=not all(not 'url' in x for x in codelist_json['data']),
-                show_status_column=any('status' in x and x['status'] != 'active' for x in codelist_json['data']),
+                show_withdrawn=any('status' in x and x['status'] != 'active' for x in codelist_json['data']),
                 fname=fname,
                 len=len,
                 github_url=github_url,

--- a/gen.py
+++ b/gen.py
@@ -519,6 +519,7 @@ def codelists_to_docs(lang):
                 codelist_json=codelist_json,
                 show_category_column=not all(not 'category' in x for x in codelist_json['data']),
                 show_url_column=not all(not 'url' in x for x in codelist_json['data']),
+                show_status_column=any('status' in x and x['status'] != 'active' for x in codelist_json['data']),
                 fname=fname,
                 len=len,
                 github_url=github_url,

--- a/templates/en/codelist.rst
+++ b/templates/en/codelist.rst
@@ -68,9 +68,12 @@ Codes
      - Public Database?{% endif %}
 
    {% for codelist_item in codelist_json.data %}
-       {% if codelist_item.status == 'withdrawn' %} .. rst-class:: withdrawn
+       {% if codelist_item.status == 'withdrawn' %} 
+       .. rst-class:: withdrawn
+   * - {{codelist_item.code + " (withdrawn)"}}
+       {% else %}
+   * - {{codelist_item.code}}   
        {% endif %}
-   * - {{codelist_item.code}}
      - {{codelist_item.name}}
      - {% if codelist_item.description %}{{codelist_item.description}}{% endif %}{% if show_category_column %}
      - {% if codelist_item.category %}{% if codelist_json.attributes['category-codelist'] %}:ref:`{{codelist_item.category}} <{{codelist_json.attributes['category-codelist']}}>`{%else%}{{codelist_item.category}}{%endif%}{% endif %}{% endif %}{% if show_url_column %}

--- a/templates/en/codelist.rst
+++ b/templates/en/codelist.rst
@@ -60,7 +60,8 @@ Codes
      - Description{% if show_category_column %}
      - Category{% endif %}{% if show_url_column %}
      - URL{% endif %}{% if fname == 'OrganisationRegistrationAgency' %}
-     - Public Database?{% endif %}
+     - Public Database?{% endif %}{% if show_status_column %}
+     - Status{% endif %}
 
    {% for codelist_item in codelist_json.data %}
 
@@ -69,7 +70,8 @@ Codes
      - {% if codelist_item.description %}{{codelist_item.description}}{% endif %}{% if show_category_column %}
      - {% if codelist_item.category %}{% if codelist_json.attributes['category-codelist'] %}:ref:`{{codelist_item.category}} <{{codelist_json.attributes['category-codelist']}}>`{%else%}{{codelist_item.category}}{%endif%}{% endif %}{% endif %}{% if show_url_column %}
      - {% if codelist_item.url %}{{codelist_item.url}}{% endif %}{% if fname == 'OrganisationRegistrationAgency' %}
-     - {{codelist_item['public-database']}}{% endif %}{% endif %}
+     - {{codelist_item['public-database']}}{% endif %}{% endif %}{% if show_status_column %}
+     - {% if codelist_item.status == 'withdrawn' %}Withdrawn{% endif %}{% endif %}
 
    {% endfor %}
 

--- a/templates/en/codelist.rst
+++ b/templates/en/codelist.rst
@@ -47,6 +47,11 @@ Download this codelist
 
 `GitHub Source <{{github_url}}>`__
 
+{% if show_withdrawn and embedded==False %}
+
+This codelist has some withdrawn elements, for details on these check the `Non-Embedded Codelist changelog record <http://iatistandard.org/upgrades/nonembedded-codelist-changelog>`__
+{% endif %}
+
 Codes
 -----
 
@@ -60,19 +65,17 @@ Codes
      - Description{% if show_category_column %}
      - Category{% endif %}{% if show_url_column %}
      - URL{% endif %}{% if fname == 'OrganisationRegistrationAgency' %}
-     - Public Database?{% endif %}{% if show_status_column %}
-     - Status{% endif %}
+     - Public Database?{% endif %}
 
    {% for codelist_item in codelist_json.data %}
-
+       {% if codelist_item.status == 'withdrawn' %} .. rst-class:: withdrawn
+       {% endif %}
    * - {{codelist_item.code}}
      - {{codelist_item.name}}
      - {% if codelist_item.description %}{{codelist_item.description}}{% endif %}{% if show_category_column %}
      - {% if codelist_item.category %}{% if codelist_json.attributes['category-codelist'] %}:ref:`{{codelist_item.category}} <{{codelist_json.attributes['category-codelist']}}>`{%else%}{{codelist_item.category}}{%endif%}{% endif %}{% endif %}{% if show_url_column %}
      - {% if codelist_item.url %}{{codelist_item.url}}{% endif %}{% if fname == 'OrganisationRegistrationAgency' %}
-     - {{codelist_item['public-database']}}{% endif %}{% endif %}{% if show_status_column %}
-     - {% if codelist_item.status == 'withdrawn' %}Withdrawn{% endif %}{% endif %}
-
+     - {{codelist_item['public-database']}}{% endif %}{% endif %}
    {% endfor %}
 
 {{extra_docs}}


### PR DESCRIPTION
This relies on IATI/IATI-Codelists#155.

It adds a “Status” column to the codes tables like this one:
http://iatistandard.org/codelists/Sector/#codes

The values in the cells of the status column are either:
 - blank for active codes, or
 - “Withdrawn” for withdrawn codes.

`withdrawal-date` and `activation-date` are not shown.

Refs #142.

Looks like this:
![screencast](https://user-images.githubusercontent.com/464193/42476318-dd3b183e-83cd-11e8-9826-85c77c66042c.gif)
