### PR TITLE
Show withdrawn codelist codes as withdrawn (v1.05)

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -158,7 +158,7 @@ class Schema2Doc(object):
         self.tree2 = ET.parse("./IATI-Schemas/iati-common.xsd")
         self.jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader('templates'))
         self.lang = lang
-        
+
         self.jinja_env.filters['is_complete_codelist'] = is_complete_codelist
 
     def get_schema_element(self, tag_name, name_attribute):
@@ -409,6 +409,7 @@ def codelists_to_docs(lang):
             t = jinja_env.get_template(lang+'/codelist.rst')
             fp.write(t.render(
                 codelist_json=codelist_json,
+                show_withdrawn=any('status' in x and x['status'] != 'active' for x in codelist_json['data']),
                 fname=fname,
                 len=len,
                 github_url=github_url,

--- a/templates/en/codelist.rst
+++ b/templates/en/codelist.rst
@@ -43,6 +43,11 @@ Download this codelist
 
 `GitHub Source (New XML) <{{github_url}}>`__
 
+{% if show_withdrawn and embedded==False %}
+
+This codelist has some withdrawn elements, for details on these check the `Non-Embedded Codelist changelog record <http://iatistandard.org/upgrades/nonembedded-codelist-changelog>`__
+{% endif %}
+
 Codes
 -----
 
@@ -60,13 +65,17 @@ Codes
 
    {% for codelist_item in codelist_json.data %}
 
+       {% if codelist_item.status == 'withdrawn' %}
+       .. rst-class:: withdrawn
+   * - {{codelist_item.code + " (withdrawn)"}}
+       {% else %}
    * - {{codelist_item.code}}
+       {% endif %}
      - {{codelist_item.name}}
      - {% if codelist_item.description %}{{codelist_item.description}}{% endif %}
      - {% if codelist_item.category %}{% if codelist_json.attributes['category-codelist'] %}:ref:`{{codelist_item.category}} <{{codelist_json.attributes['category-codelist']}}>`{%else%}{{codelist_item.category}}{%endif%}{% endif %}
      - {% if codelist_item.url %}{{codelist_item.url}}{% endif %}
 {% if fname == 'OrganisationRegistrationAgency' %}     - {{codelist_item['public-database']}}{% endif %}
-
    {% endfor %}
 
 {{extra_docs}}


### PR DESCRIPTION
As mentioned here: https://github.com/IATI/IATI-Standard-SSOT/pull/175#issuecomment-403628356, the HTML wasn’t originally fixed for v1.04 or v1.05, because there were some small discrepancies and I wasn’t sure how the (erstwhile) tech team wanted these handled. This PR ignores those discrepancies and just duplicates the related v2.0x PRs to add the requisite changes.

See #175 for more information.