### PR TITLE
Take document-link documentation from documentLinkBase 

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -212,6 +212,10 @@ class Schema2Doc(object):
             str: The documentation string, extracted from the input ref_element or element.
         """
         if type_element is not None:
+            if(element.get("name") == "document-link" and type_element.find(".//xsd:extension", namespaces=namespaces) is not None):
+                base_name = type_element.find(".//xsd:extension", namespaces=namespaces).get("base")
+                base_element = self.tree2.find("xsd:{0}[@name='{1}']".format("complexType", base_name), namespaces=namespaces)
+                return base_element.find(".//xsd:documentation", namespaces=namespaces).text
             xsd_documentation = type_element.find(".//xsd:documentation", namespaces=namespaces)
             if xsd_documentation is not None:
                 return type_element.find(".//xsd:documentation", namespaces=namespaces).text


### PR DESCRIPTION
Attempting to fix #200 and #199, change `gen.py/schema_documentation` so that document-link elements take their documentation from [documentLinkBase](https://github.com/IATI/IATI-Schemas/blob/a96c582f2f6873aa46b42df2d24d69f3128b24e4/iati-common.xsd#L181) instead of [documentLinkWithReceipientCountry](https://github.com/IATI/IATI-Schemas/blob/a96c582f2f6873aa46b42df2d24d69f3128b24e4/iati-organisations-schema.xsd#L769)[sic]
