### PR TITLE
Don’t use `.//`, since it returns all descendants (v2.03)

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -396,14 +396,18 @@ class Schema2Doc(object):
         if 'type' in a:
             complexType = self.get_schema_element('complexType', a['type'])
             if complexType is not None:
-                type_elements = ( complexType.findall('.//xsd:choice/xsd:element', namespaces=namespaces) +
-                    complexType.findall('.//xsd:sequence/xsd:element', namespaces=namespaces) )
+                type_elements = (
+                    complexType.findall('xsd:choice/xsd:element', namespaces=namespaces) +
+                    complexType.findall('xsd:sequence/xsd:element', namespaces=namespaces) +
+                    complexType.findall('xsd:complexContent/xsd:extension/xsd:sequence/xsd:element', namespaces=namespaces))
 
                 # If this complexType is an extension of another complexType, find the base element and include any child elements
                 try:
-                    base_name = complexType.find('.//xsd:complexContent/xsd:extension', namespaces=namespaces).attrib.get('base')
+                    base_name = complexType.find('xsd:complexContent/xsd:extension', namespaces=namespaces).attrib.get('base')
                     base_type_element = self.get_schema_element('complexType', base_name)
-                    type_elements += ( base_type_element.findall('.//xsd:choice/xsd:element', namespaces=namespaces) + base_type_element.findall('.//xsd:sequence/xsd:element', namespaces=namespaces) )
+                    type_elements += (
+                        base_type_element.findall('xsd:choice/xsd:element', namespaces=namespaces) +
+                        base_type_element.findall('xsd:sequence/xsd:element', namespaces=namespaces))
                 except AttributeError:
                     pass
                     # This complexType is not extended from a complexType base


### PR DESCRIPTION
Refs #200.