### PR TITLE
Fix generic element descriptions on reference site (v2.02)

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -214,9 +214,23 @@ class Schema2Doc(object):
         if ref_element is not None:
             xsd_docuementation = ref_element.find(".//xsd:documentation", namespaces=namespaces)
             if xsd_docuementation is not None:
-                return ref_element.find(".//xsd:documentation", namespaces=namespaces).text
-        return element.find(".//xsd:documentation", namespaces=namespaces).text
+                return xsd_docuementation.text
 
+        xsd_documentation = element.find(".//xsd:documentation", namespaces=namespaces)
+        if xsd_documentation is not None:
+            return xsd_documentation.text
+
+        if type_element is not None:
+            xsd_documentation = type_element.find(".//xsd:documentation", namespaces=namespaces)
+            if xsd_documentation is not None:
+                return xsd_documentation.text
+
+            extension = type_element.find(".//xsd:extension", namespaces=namespaces)
+            if extension is not None:
+                base_name = type_element.find(".//xsd:extension", namespaces=namespaces).get("base")
+                base_element = self.get_schema_element('complexType', base_name)
+                if base_element is not None:
+                    return base_element.find(".//xsd:documentation", namespaces=namespaces).text
 
     def output_docs(self, element_name, path, element=None, minOccurs='', maxOccurs='', ref_element=None):
 


### PR DESCRIPTION
Duplicate of #241, for the `version-2.02` branch.

This doesn’t affect the output at all – it’s just to keep this code roughly in sync with the code on the `version-2.03` branch.

Refs #212.