### PR TITLE
 Fix `narrative/@xml:lang` by using base complex type instead of the first complex type. (1.04)

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -343,8 +343,17 @@ class Schema2Doc(object):
         type_attributeGroups = []
         if 'type' in a:
             complexType = self.get_schema_element('complexType', a['type'])
+
+            # If this complexType is an extension of another complexType, find the base element and use this to find any attributes
+            try:
+                base_name = complexType.find('.//xsd:complexContent/xsd:extension', namespaces=namespaces).attrib.get('base')
+                complexType = self.get_schema_element('complexType', base_name)
+            except AttributeError:
+                pass
+                # This complexType is not extended from a complexType base
+
             if complexType is None:
-                print 'Notice: No attributes for', a['type']
+                print('Notice: No attributes for', a['type'])
             else:
                 type_attributes = (
                     complexType.findall('xsd:attribute', namespaces=namespaces) +


### PR DESCRIPTION
Addresses issue #228 