### PR TITLE
Specifying when codelists were translated

### DIFF
--- a/templates/en/codelist.rst
+++ b/templates/en/codelist.rst
@@ -52,7 +52,7 @@ Download this codelist
 This codelist has some withdrawn elements, for details on these check the `Non-Embedded Codelist changelog record <http://iatistandard.org/upgrades/nonembedded-codelist-changelog>`__
 {% endif %}
 
-The codelists were translated in French in April 2018 with the support of the Government of Canada. Please note that if any codelist have been added since then, they are not currently available in French.
+The codelists were translated in French in April 2018 with the support of the Government of Canada. Please note that if any codelists have been added since then, they will not be currently available in French.
 
 Codes
 -----

--- a/templates/en/codelist.rst
+++ b/templates/en/codelist.rst
@@ -52,6 +52,8 @@ Download this codelist
 This codelist has some withdrawn elements, for details on these check the `Non-Embedded Codelist changelog record <http://iatistandard.org/upgrades/nonembedded-codelist-changelog>`__
 {% endif %}
 
+The codelists were translated in French in April 2018 with the support of the Government of Canada. Please note that if any codelist have been added since then, they are not currently available in French.
+
 Codes
 -----
 


### PR DESCRIPTION
Added a sentence to specify when French version of the codelists was created.