### PR TITLE
[2.03] Downgrade sphinx to 1.6.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip==19.2.1
-Sphinx==2.1.2
+Sphinx==1.6.7
 lxml==4.4.0
 flake8==3.7.8
 Jinja2==2.10.1


### PR DESCRIPTION
Fixes #344, and removes extra links included on the sidebar:

![Screenshot 2019-08-28 at 16 38 23](https://user-images.githubusercontent.com/464193/63870651-46c22100-c9b2-11e9-9c93-ae73899be862.png)
